### PR TITLE
Migrate the Ballerina Gmail connector to Ballerina version 1.0.0

### DIFF
--- a/Ballerina.lock
+++ b/Ballerina.lock
@@ -1,7 +1,7 @@
 org_name = "wso2"
 version = "1.0.0"
 lockfile_version = "1.0.0"
-ballerina_version = "1.0.0-rc1-SNAPSHOT"
+ballerina_version = "1.0.0"
 
 [[imports."wso2/gmail:1.0.0"]]
 org_name = "ballerinax"

--- a/Ballerina.toml
+++ b/Ballerina.toml
@@ -1,6 +1,6 @@
 [project]
 org-name= "wso2"
-version= "1.0.0"
+version= "0.10.0"
 authors = ["WSO2"]
 repository = "https://github.com/wso2-ballerina/module-gmail"
 keywords = ["gmail","email"]

--- a/Readme.md
+++ b/Readme.md
@@ -1,94 +1,97 @@
 [![Build Status](https://travis-ci.org/wso2-ballerina/module-gmail.svg?branch=master)](https://travis-ci.org/wso2-ballerina/module-gmail)
 
-Connects to Gmail from Ballerina. 
+# Ballerina Gmail Connector
 
-# module Overview
+Ballerina Gmail Connector provides the capability to send, read and delete emails through the Gmail REST API. It also provides the ability to read, trash, untrash and delete threads, ability to get the Gmail profile and mailbox history, etc. The connector handles OAuth 2.0 authentication.
 
-The Gmail connector allows you to send, read, and delete emails through the Gmail REST API. It handles OAuth 2.0 
-authentication. It also provides the ability to read, trash, untrash, delete threads, get the Gmail profile, mailbox 
-history, etc.
+The following sections provide you with information on how to use the Ballerina Gmail Connector.
 
-**Working with Messages**
+- [Compatibility](#compatibility)
+- [Feature Overview](#feature-overview)
+- [Getting Started](#getting-started)
+- [Sample](#sample)
 
-The `wso2/gmail` module contains operations to send emails in Text and HTML formats with attachments and inline images. 
-It supports searching and reading messages in Gmail using Gmail filters. The module also supports trashing, untrashing, 
-deleting, and modifying messages as well.
+## Compatibility
 
-**Working with Threads**
+| Ballerina Language Version  | Gmail API Version |
+|:---------------------------:|:------------------------------:|
+|  1.0.0                     |   v1                           |
 
-The `wso2/gmail` module contains operations to read, search, trash, untrash, modify, and delete mail threads in Gmail.
+## Feature Overview
 
-**Working with Drafts**
+#### Working with Emails
 
-The `wso2/gmail` module contains operations to search, read, delete, create, update, and send drafts in Gmail.   
+The `wso2/gmail` module contains operations to send emails in Text and HTML formats with attachments and inline images. It supports searching and reading emails in Gmail using Gmail filters. The module also supports trashing, untrashing, deleting, and modifying emails.
 
-**Working with Labels**
+#### Working with Threads
 
-The `wso2/gmail` module containes operations to list, read, create, update, and delete labels in Gmail.
+The `wso2/gmail` module contains operations to read, search, trash, untrash, modify and delete email threads in Gmail.
 
-**Working with User Profiles**
+#### Working with Drafts
+
+The `wso2/gmail` module contains operations to search, read, delete, create, update and send drafts in Gmail.
+
+#### Working with Labels
+
+The `wso2/gmail` module containes operations to list, read, create, update and delete labels in Gmail.
+
+#### Working with User Profiles
 
 The `wso2/gmail` module contains operations to get Gmail user profile details.
 
-**Working with User History**
+#### Working with Mailbox History
 
 The `wso2/gmail` module contains operations to lists the history of changes to the user's mailbox.
 
-## Compatibility
-|                    |    Version     |  
-|:------------------:|:--------------:|
-| Ballerina Language | 1.0            |
-| Gmail API          | v1             |
+## Getting Started
+
+### Prerequisites
+Download and install [Ballerina](https://ballerinalang.org/downloads/).
+
+### Pull the Module
+You can pull the Gmail module from Ballerina Central using the command:
+```ballerina
+$ ballerina pull wso2/gmail
+```
 
 ## Sample
 First, import the `wso2/gmail` module into the Ballerina project.
 ```ballerina
 import wso2/gmail;
 ```
-Instantiate the connector by giving authentication details in the HTTP client config, which has built-in support for 
-BasicAuth and OAuth 2.0. Gmail uses OAuth 2.0 to authenticate and authorize requests. The Gmail connector can be 
-minimally instantiated in the HTTP client config using the access token or using the client ID, client secret, 
-and refresh token.
+Instantiate the connector by giving authentication details in the Gmail client config, which has built-in support for OAuth 2.0. Gmail uses OAuth 2.0 to authenticate and authorize requests. The Gmail connector can be minimally instantiated in the Gmail client config using the Access Token or by using the Client ID, Client Secret and Refresh Token.
 
 **Obtaining Tokens to Run the Sample**
 
 1. Visit [Google API Console](https://console.developers.google.com), click **Create Project**, and follow the wizard to create a new project.
-2. Go to **Credentials -> OAuth consent screen**, enter a product name to be shown to users, and click **Save**.
-3. On the **Credentials** tab, click **Create credentials** and select **OAuth client ID**. 
+2. Go to **Credentials -> OAuth Consent Screen**, enter a product name to be shown to users, and click **Save**.
+3. On the **Credentials** tab, click **Create Credentials** and select **OAuth Client ID**.
 4. Select an application type, enter a name for the application, and specify a redirect URI (enter https://developers.google.com/oauthplayground if you want to use 
-[OAuth 2.0 playground](https://developers.google.com/oauthplayground) to receive the authorization code and obtain the 
-access token and refresh token). 
-5. Click **Create**. Your client ID and client secret appear. 
-6. In a separate browser window or tab, visit [OAuth 2.0 playground](https://developers.google.com/oauthplayground). Click on the `OAuth 2.0 configuration`
- icon in the top right corner and click on `Use your own OAuth credentials` and provide your `OAuth Client ID` and `OAuth Client secret`.
+[OAuth 2.0 Playground](https://developers.google.com/oauthplayground) to receive the Authorization Code and obtain the 
+Access Token and Refresh Token).
+5. Click **Create**. Your Client ID and Client Secret will appear.
+6. In a separate browser window or tab, visit [OAuth 2.0 Playground](https://developers.google.com/oauthplayground). Click on the `OAuth 2.0 Configuration`
+ icon in the top right corner and click on `Use your own OAuth credentials` and provide your `OAuth Client ID` and `OAuth Client Secret`.
 7. Select the required Gmail API scopes from the list of API's, and then click **Authorize APIs**.
 8. When you receive your authorization code, click **Exchange authorization code for tokens** to obtain the refresh token and access token.
 
-You can now enter the credentials in the HTTP client config. 
+You can now enter the credentials in the Gmail client config.
 ```ballerina
 gmail:GmailConfiguration gmailConfig = {
-    clientConfig: {
-        auth: {
-            scheme: http:OAUTH2,
-            config: {
-                grantType: http:DIRECT_TOKEN,
-                config: {
-                    accessToken: testAccessToken,
-                    refreshConfig: {
-                        refreshUrl: gmail:REFRESH_URL,
-                        refreshToken: testRefreshToken,
-                        clientId: testClientId,
-                        clientSecret: testClientSecret
-                    }
-                }
-            }
+    oauthClientConfig: {
+        accessToken: <ACCESS_TOKEN>,
+        refreshConfig: {
+            refreshUrl: gmail:REFRESH_URL,
+            refreshToken: <REFRESH_TOKEN>,
+            clientId: <CLIENT_ID>,
+            clientSecret: <CLIENT_SECRET>
         }
     }
 };
 
-gmail:Client gmailClient = new(gmailConfig);
+gmail:Client gmailClient = new (gmailConfig);
 ```
-The `sendMessage` remote function sends an email. `MessageRequest` is an object that contains all the data that is required
+The `sendMessage` remote function sends an email. `MessageRequest` object which contains all the data is required
 to send an email. The `userId` represents the authenticated user and can be a Gmail address or ‘me’ 
 (the currently authenticated user).
 
@@ -110,9 +113,9 @@ The response from `sendMessage` is either a string tuple with the message ID and
 (if the message was sent successfully) or an `error` (if sending the message was unsuccessful).
 
 ```ballerina
-if (sendMessageResponse is (string, string)) {
+if (sendMessageResponse is [string, string]) {
     // If successful, print the message ID and thread ID.
-    (string, string) (messageId, threadId) = sendMessageResponse;
+    [string, string][messageId, threadId] = sendMessageResponse;
     io:println("Sent Message ID: " + messageId);
     io:println("Sent Thread ID: " + threadId);
 } else {
@@ -124,7 +127,7 @@ if (sendMessageResponse is (string, string)) {
 The `readMessage` remote function reads messages. It returns the `Message` object when successful or an `error` when unsuccessful.
 
 ```ballerina
-var response = gmailClient->readMessage(userId, untaint messageId);
+var response = gmailClient->readMessage(userId, <@untainted>messageId);
 if (response is gmail:Message) {
     io:println("Sent Message: " + response);
 } else {
@@ -135,10 +138,10 @@ if (response is gmail:Message) {
 The `deleteMessage` remote function deletes messages. It returns an `error` when unsuccessful.
 
 ```ballerina    
-var delete = gmailClient->deleteMessage(userId, untaint messageId);
-if (delete is boolean) {
-    io:println("Message deletion success!");
-} else {
+var delete = gmailClient->deleteMessage(userId, <@untainted>messageId);
+if (delete is error) {
     io:println("Error: ", delete);
+} else {
+    io:println("Message deletion success!");
 }
 ```

--- a/src/gmail/Module.md
+++ b/src/gmail/Module.md
@@ -1,102 +1,100 @@
-Connects to Gmail from Ballerina. 
+# Ballerina Gmail Connector
 
-# Module Overview
+Ballerina Gmail Connector provides the capability to send, read and delete emails through the Gmail REST API. It also provides the ability to read, trash, untrash and delete threads, ability to get the Gmail profile and mailbox history, etc. The connector handles OAuth 2.0 authentication.
 
-The Gmail connector allows you to send, read, and delete emails through the Gmail REST API. It handles OAuth 2.0 
-authentication. It also provides the ability to read, trash, untrash, delete threads, get the Gmail profile, mailbox 
-history, etc.
+The following sections provide you with information on how to use the Ballerina Gmail Connector.
 
-**Working with Messages**
+- [Compatibility](#compatibility)
+- [Feature Overview](#feature-overview)
+- [Getting Started](#getting-started)
+- [Sample](#sample)
 
-The `wso2/gmail` module contains operations to send emails in Text and HTML formats with attachments and inline images. 
-It supports searching and reading messages in Gmail using Gmail filters. The module also supports trashing, untrashing, 
-deleting, and modifying messages as well.
+## Compatibility
 
-**Working with Threads**
+| Ballerina Language Version  | Gmail API Version |
+|:---------------------------:|:------------------------------:|
+|  1.0.0                     |   v1                           |
 
-The `wso2/gmail` module contains operations to read, search, trash, untrash, modify, and delete mail threads in Gmail.
+## Feature Overview
 
-**Working with Drafts**
+#### Working with Emails
 
-The `wso2/gmail` module contains operations to search, read, delete, create, update, and send drafts in Gmail.   
+The `wso2/gmail` module contains operations to send emails in Text and HTML formats with attachments and inline images. It supports searching and reading emails in Gmail using Gmail filters. The module also supports trashing, untrashing, deleting, and modifying emails.
 
-**Working with Labels**
+#### Working with Threads
 
-The `wso2/gmail` module containes operations to list, read, create, update, and delete labels in Gmail.
+The `wso2/gmail` module contains operations to read, search, trash, untrash, modify and delete email threads in Gmail.
 
-**Working with User Profiles**
+#### Working with Drafts
+
+The `wso2/gmail` module contains operations to search, read, delete, create, update and send drafts in Gmail.
+
+#### Working with Labels
+
+The `wso2/gmail` module containes operations to list, read, create, update and delete labels in Gmail.
+
+#### Working with User Profiles
 
 The `wso2/gmail` module contains operations to get Gmail user profile details.
 
-**Working with User History**
+#### Working with Mailbox History
 
 The `wso2/gmail` module contains operations to lists the history of changes to the user's mailbox.
 
-## Compatibility
-|                    |    Version     |  
-|:------------------:|:--------------:|
-| Ballerina Language | 1.0            |
-| Gmail API          | v1             |
+## Getting Started
+
+### Prerequisites
+Download and install [Ballerina](https://ballerinalang.org/downloads/).
+
+### Pull the Module
+You can pull the Gmail module from Ballerina Central using the command:
+```ballerina
+$ ballerina pull wso2/gmail
+```
 
 ## Sample
 First, import the `wso2/gmail` module into the Ballerina project.
 ```ballerina
 import wso2/gmail;
 ```
-Instantiate the connector by giving authentication details in the HTTP client config, which has built-in support for 
-BasicAuth and OAuth 2.0. Gmail uses OAuth 2.0 to authenticate and authorize requests. The Gmail connector can be 
-minimally instantiated in the HTTP client config using the access token or using the client ID, client secret, 
-and refresh token.
+Instantiate the connector by giving authentication details in the Gmail client config, which has built-in support for OAuth 2.0. Gmail uses OAuth 2.0 to authenticate and authorize requests. The Gmail connector can be minimally instantiated in the Gmail client config using the Access Token or by using the Client ID, Client Secret and Refresh Token.
 
 **Obtaining Tokens to Run the Sample**
 
 1. Visit [Google API Console](https://console.developers.google.com), click **Create Project**, and follow the wizard to create a new project.
-2. Go to **Credentials -> OAuth consent screen**, enter a product name to be shown to users, and click **Save**.
-3. On the **Credentials** tab, click **Create credentials** and select **OAuth client ID**. 
+2. Go to **Credentials -> OAuth Consent Screen**, enter a product name to be shown to users, and click **Save**.
+3. On the **Credentials** tab, click **Create Credentials** and select **OAuth Client ID**.
 4. Select an application type, enter a name for the application, and specify a redirect URI (enter https://developers.google.com/oauthplayground if you want to use 
-[OAuth 2.0 playground](https://developers.google.com/oauthplayground) to receive the authorization code and obtain the 
-access token and refresh token). 
-5. Click **Create**. Your client ID and client secret appear. 
-6. In a separate browser window or tab, visit [OAuth 2.0 playground](https://developers.google.com/oauthplayground). Click on the `OAuth 2.0 configuration`
- icon in the top right corner and click on `Use your own OAuth credentials` and provide your `OAuth Client ID` and `OAuth Client secret`.
+[OAuth 2.0 Playground](https://developers.google.com/oauthplayground) to receive the Authorization Code and obtain the 
+Access Token and Refresh Token).
+5. Click **Create**. Your Client ID and Client Secret will appear.
+6. In a separate browser window or tab, visit [OAuth 2.0 Playground](https://developers.google.com/oauthplayground). Click on the `OAuth 2.0 Configuration`
+ icon in the top right corner and click on `Use your own OAuth credentials` and provide your `OAuth Client ID` and `OAuth Client Secret`.
 7. Select the required Gmail API scopes from the list of API's, and then click **Authorize APIs**.
 8. When you receive your authorization code, click **Exchange authorization code for tokens** to obtain the refresh token and access token.
 
-You can now enter the credentials in the HTTP client config. 
+You can now enter the credentials in the Gmail client config.
 ```ballerina
 gmail:GmailConfiguration gmailConfig = {
-    clientConfig: {
-        auth: {
-            scheme: http:OAUTH2,
-            config: {
-                grantType: http:DIRECT_TOKEN,
-                config: {
-                    accessToken: <ACCESS_TOKEN>,
-                    refreshConfig: {
-                        refreshUrl: gmail:REFRESH_URL,
-                        refreshToken: <REFRESH_TOKEN>,
-                        clientId: <CLIENT_ID>,
-                        clientSecret: <CLIENT_SECRET>,
-                        clientConfig: {
-                            secureSocket:{
-                                trustStore:{
-                                    path: <TRUST_STORE_PATH>,
-                                    password: <TRUST_STORE_PASSWORD>
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+    oauthClientConfig: {
+        accessToken: <ACCESS_TOKEN>,
+        refreshConfig: {
+            refreshUrl: gmail:REFRESH_URL,
+            refreshToken: <REFRESH_TOKEN>,
+            clientId: <CLIENT_ID>,
+            clientSecret: <CLIENT_SECRET>
         }
     }
 };
-gmail:Client gmailClient = new(gmailConfig);
+
+gmail:Client gmailClient = new (gmailConfig);
 ```
-The `sendMessage` remote function sends an email. `MessageRequest` is an object that contains all the data that is required
-to send an email. The `userId` represents the authenticated user and can be a Gmail address or "me" (the current authenticated user).
+The `sendMessage` remote function sends an email. `MessageRequest` object which contains all the data is required
+to send an email. The `userId` represents the authenticated user and can be a Gmail address or ‘me’ 
+(the currently authenticated user).
 
 ```ballerina
+string userId = "me";
 gmail:MessageRequest messageRequest = {};
 messageRequest.recipient = "recipient@mail.com";
 messageRequest.sender = "sender@mail.com";
@@ -109,12 +107,13 @@ messageRequest.contentType = gmail:TEXT_PLAIN;
 var sendMessageResponse = gmailClient->sendMessage(userId, messageRequest);
 ```
 
-The response from `sendMessage` is either a string tuple with the message ID and thread ID (if the message was sent successfully) or an `error` (if sending the message was unsuccessful).
+The response from `sendMessage` is either a string tuple with the message ID and thread ID 
+(if the message was sent successfully) or an `error` (if sending the message was unsuccessful).
 
 ```ballerina
-if (sendMessageResponse is (string, string)) {
+if (sendMessageResponse is [string, string]) {
     // If successful, print the message ID and thread ID.
-    (string, string) (messageId, threadId) = sendMessageResponse;
+    [string, string][messageId, threadId] = sendMessageResponse;
     io:println("Sent Message ID: " + messageId);
     io:println("Sent Thread ID: " + threadId);
 } else {
@@ -126,7 +125,7 @@ if (sendMessageResponse is (string, string)) {
 The `readMessage` remote function reads messages. It returns the `Message` object when successful or an `error` when unsuccessful.
 
 ```ballerina
-var response = gmailClient->readMessage(userId, messageIdToRead);
+var response = gmailClient->readMessage(userId, <@untainted>messageId);
 if (response is gmail:Message) {
     io:println("Sent Message: " + response);
 } else {
@@ -137,48 +136,33 @@ if (response is gmail:Message) {
 The `deleteMessage` remote function deletes messages. It returns an `error` when unsuccessful.
 
 ```ballerina    
-var delete = gmailClient->deleteMessage(userId, messageIdToDelete);
-if (delete is boolean) {
-    io:println("Message deletion successful!");
-} else {
+var delete = gmailClient->deleteMessage(userId, <@untainted>messageId);
+if (delete is error) {
     io:println("Error: ", delete);
+} else {
+    io:println("Message deletion success!");
 }
 ```
 
-## Example
+### Example:
 
 ```ballerina
 import ballerina/http;
 import ballerina/io;
 import wso2/gmail;
+
 gmail:GmailConfiguration gmailConfig = {
-    clientConfig: {
-        auth: {
-            scheme: http:OAUTH2,
-            config: {
-                grantType: http:DIRECT_TOKEN,
-                config: {
-                    accessToken: <ACCESS_TOKEN>,
-                    refreshConfig: {
-                        refreshUrl: gmail:REFRESH_URL,
-                        refreshToken: <REFRESH_TOKEN>,
-                        clientId: <CLIENT_ID>,
-                        clientSecret: <CLIENT_SECRET>,
-                        clientConfig: {
-                            secureSocket:{
-                                trustStore:{
-                                    path: <TRUST_STORE_PATH>,
-                                    password: <TRUST_STORE_PASSWORD>
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+    oauthClientConfig: {
+        accessToken: <ACCESS_TOKEN>,
+        refreshConfig: {
+            refreshUrl: gmail:REFRESH_URL,
+            refreshToken: <REFRESH_TOKEN>,
+            clientId: <CLIENT_ID>,
+            clientSecret: <CLIENT_SECRET>
         }
     }
 };
-gmail:Client gmailClient = new(gmailConfig);
+gmail:Client gmailClient = new (gmailConfig);
 public function main(string... args) {
     gmail:MessageRequest messageRequest = {};
     messageRequest.recipient = "aa@gmail.com";
@@ -191,9 +175,9 @@ public function main(string... args) {
     string userId = "me";
     // Send the message.
     var sendMessageResponse = gmailClient->sendMessage(userId, messageRequest);
-    if (sendMessageResponse is (string, string)) {
+    if (sendMessageResponse is [string, string]) {
         // If successful, print the message ID and thread ID.
-        (string, string) (messageId, threadId) = sendMessageResponse;
+        [string, string] [messageId, threadId] = sendMessageResponse;
         io:println("Sent Message ID: " + messageId);
         io:println("Sent Thread ID: " + threadId);
     } else {

--- a/src/gmail/gmail_endpoint.bal
+++ b/src/gmail/gmail_endpoint.bal
@@ -16,7 +16,6 @@
 
 import ballerina/http;
 import ballerina/io;
-import ballerina/log;
 import ballerina/oauth2;
 
 # Gmail Client object.
@@ -41,13 +40,9 @@ public type Client client object {
                 secureSocket: result
             });
         } else {
-            log:printWarn("An unsecured connection is establishing since SSL configuration not provided.");
             self.gmailClient = new (BASE_URL, {
                 auth: {
                     authHandler: bearerHandler
-                },
-                secureSocket: {
-                    disable: true
                 }
             });
         }

--- a/src/gmail/tests/README.md
+++ b/src/gmail/tests/README.md
@@ -16,16 +16,17 @@
 valid Access Token vise versa.*
 
 * Go through the following steps to obtain client id, client secret, refresh token and access token for Gmail API.
-    *   Go to Google APIs console to create a project and create an app for the project to connect with Gmail API.
+    *   Go to [Google API Console](https://console.developers.google.com) to create a project and an app for the project to connect with Gmail API.
     
-    *   Configure the OAuth consent screen under Credentials and give a product name to shown to users.
+    *   Configure the OAuth consent screen under **Credentials** and give a product name to shown to users.
     
-    *   Create OAuth client ID credentials by selecting an application type and giving a name and a redirect URI. 
+    *   Create OAuth Client ID credentials by selecting an application type and giving a name and a redirect URI.
 
-        *Give the redirect URI as (https://developers.google.com/oauthplayground), if you are using OAuth2 playground to 
-        receive the authorization code and obtain access token and refresh token.*
+    *Give the redirect URI as (https://developers.google.com/oauthplayground), if you are using [OAuth 2.0 Playground](https://developers.google.com/oauthplayground) to
+    receive the authorization code and obtain access token and refresh token.*
 
-    *   Visit OAuth 2.0 Playground and select the required Gmail API scopes. 
+    *   Visit [OAuth 2.0 Playground](https://developers.google.com/oauthplayground) and select the required Gmail API scopes.
+
     *   Give previously obtained client id and client secret and obtain the refresh token and access token.
 
     
@@ -35,19 +36,19 @@ In order to use the Gmail connector, first you need to create a Gmail endpoint b
 
 Visit `main_test.bal` file to find the way of creating Gmail endpoint.
 
-#### Running Gmail tests
+### Running Gmail tests
 In order to run the tests, the user will need to have a Gmail account and configure the `ballerina.conf` configuration
 file with the obtained tokens and other parameters.
 
-##### ballerina.conf
+#### ballerina.conf
 ```ballerina.conf
 //Give the credentials and tokens for the authorized user
 ACCESS_TOKEN="enter your access token here"
 CLIENT_ID="enter your client id here"
 CLIENT_SECRET="enter your client secret here"
 REFRESH_TOKEN="enter your refresh token here"
-TRUST_STORE_PATH = "${ballerina.home}/bre/security/ballerinaTruststore.p12"
-TRUST_STORE_PASSWORD = "ballerina"
+TRUST_STORE_PATH = "enter a truststore path if required"
+TRUST_STORE_PASSWORD = "enter a truststore password if required"
 
 //Give values for the following to run the tests
 RECIPIENT="recipient@gmail.com"
@@ -63,44 +64,21 @@ IMAGE_CONTENT_TYPE="image/jpeg"
 Assign the values for the accessToken, clientId, clientSecret and refreshToken inside constructed endpoint in 
 main_test.bal
 in either way following,
-```ballerina
-gmail:GmailConfiguration gmailConfig = {
-    clientConfig: {
-        auth: {
-            scheme: http:OAUTH2,
-            config: {
-                grantType: http:DIRECT_TOKEN,
-                config: {
-                    accessToken: testAccessToken
-                }
-            }
-        }
-    }
-};
-```
 
 ```ballerina
-gmail:GmailConfiguration gmailConfig = {
-    clientConfig: {
+GmailConfiguration gmailConfig = {
+    oauthClientConfig: {
         accessToken: config:getAsString("ACCESS_TOKEN"),
         refreshConfig: {
-            refreshUrl: gmail:REFRESH_URL,
+            refreshUrl: REFRESH_URL,
             refreshToken: config:getAsString("REFRESH_TOKEN"),
             clientId: config:getAsString("CLIENT_ID"),
-            clientSecret: config:getAsString("CLIENT_SECRET"),
-            clientConfig: {
-                secureSocket:{
-                    trustStore:{
-                        path: config:getAsString("TRUST_STORE_PATH"),
-                        password: config:getAsString("TRUST_STORE_PASSWORD")
-                    }
-                }
-            }
+            clientSecret: config:getAsString("CLIENT_SECRET")
         }
     }
 };
 
-gmail:Client gmailClient = new(gmailConfig);
+Client gmailClient = new(gmailConfig);
 ```
 
 Assign values for other necessary parameters to perform api operations in test.bal as follows.
@@ -117,6 +95,5 @@ string imageContentType = config:getAsString("IMAGE_CONTENT_TYPE");
 Run tests :
 
 ```
-ballerina init
-ballerina test gmail --config ballerina.conf
+ballerina test gmail --b7a.config.file=<path_to_ballerina.conf>
 ```

--- a/src/gmail/tests/main_test.bal
+++ b/src/gmail/tests/main_test.bal
@@ -26,21 +26,7 @@ GmailConfiguration gmailConfig = {
             refreshUrl: REFRESH_URL,
             refreshToken: config:getAsString("REFRESH_TOKEN"),
             clientId: config:getAsString("CLIENT_ID"),
-            clientSecret: config:getAsString("CLIENT_SECRET"),
-            clientConfig: {
-                secureSocket: {
-                    trustStore: {
-                        path: config:getAsString("OAUTH_TRUST_STORE_PATH"),
-                        password: config:getAsString("OAUTH_TRUST_STORE_PASSWORD")
-                    }
-                }
-            }
-        }
-    },
-    secureSocketConfig: {
-        trustStore: {
-            path: config:getAsString("HTTP_TRUST_STORE_PATH"),
-            password: config:getAsString("HTTP_TRUST_STORE_PASSWORD")
+            clientSecret: config:getAsString("CLIENT_SECRET")
         }
     }
 };


### PR DESCRIPTION
## Purpose
* Migrate the connector to Ballerina 1.0.0 version.
* Remove the feature implemented to disable SSL when secure socket configuration is not provided, since it is sent from within the client and doesn’t require the configuration to be passed explicitly.
* Modify the README files.
* Change the version of the Ballerina Gmail connector to 0.10.0.