### PR TITLE
Migrate the Ballerina version to 1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 script:
-  - wget https://product-dist.ballerina.io/downloads/1.0.1/ballerina-linux-installer-x64-1.0.1.deb
-  - sudo dpkg -i ballerina-linux-installer-x64-1.0.1.deb
+  - wget https://product-dist.ballerina.io/downloads/1.1.0/ballerina-linux-installer-x64-1.1.0.deb
+  - sudo dpkg -i ballerina-linux-installer-x64-1.1.0.deb
   - sudo apt-get install -f
   - ballerina --version
   - ballerina build -c --skip-tests gmail

--- a/Ballerina.lock
+++ b/Ballerina.lock
@@ -1,14 +1,14 @@
 org_name = "wso2"
-version = "0.10.1"
+version = "0.11.0"
 lockfile_version = "1.0.0"
-ballerina_version = "1.0.1"
+ballerina_version = "1.1.0"
 
-[[imports."wso2/gmail:0.10.1"]]
+[[imports."wso2/gmail:0.11.0"]]
 org_name = "ballerinax"
 name = "java"
 version = "0.0.0"
 
-[[imports."wso2/gmail:0.10.1"]]
+[[imports."wso2/gmail:0.11.0"]]
 org_name = "ballerinax"
 name = "java.arrays"
 version = "0.0.0"

--- a/Ballerina.toml
+++ b/Ballerina.toml
@@ -1,6 +1,6 @@
 [project]
 org-name= "wso2"
-version= "0.10.1"
+version= "0.11.0"
 authors = ["WSO2"]
 repository = "https://github.com/wso2-ballerina/module-gmail"
 keywords = ["gmail","email"]

--- a/Readme.md
+++ b/Readme.md
@@ -13,9 +13,9 @@ The following sections provide you with information on how to use the Ballerina 
 
 ## Compatibility
 
-| Ballerina Language Version  | Gmail API Version |
+| Ballerina Language Versions  | Gmail API Version |
 |:---------------------------:|:------------------------------:|
-|  1.0.1                     |   v1                           |
+|  1.0.x, 1.1.x                   |   v1                           |
 
 ## Feature Overview
 

--- a/src/gmail/Module.md
+++ b/src/gmail/Module.md
@@ -42,9 +42,9 @@ gmail:Client gmailClient = new (gmailConfig);
 
 ## Compatibility
 
-| Ballerina Language Version  | Gmail API Version |
+| Ballerina Language Versions  | Gmail API Version |
 |:---------------------------:|:------------------------------:|
-|  1.0.1                      |   v1                           |
+|  1.0.x, 1.1.x                      |   v1                           |
 
 ## Sample
 


### PR DESCRIPTION
## Purpose
> Migrate the Gmail Connector from Ballerina version 1.0.1 to 1.1.0. 
